### PR TITLE
Properly scope markdown code block

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
- 1872  virtualenv -p python3.5m virtualenv-3.5
- 1873  . virtualenv-3.5/bin/activate
- 1874  pip install pycuda
- 1875  PATH=$PATH:/usr/local/cuda-10.0/bin pip install pycuda
- 1876  pip install numpy
- 1877  PATH=$PATH:/usr/local/cuda-10.0/bin pip install pycuda
 
+## Executing
+
+ ```sh
+virtualenv -p python3.5m virtualenv-3.5
+. virtualenv-3.5/bin/activate
+pip install pycuda
+PATH=$PATH:/usr/local/cuda-10.0/bin pip install pycuda
+pip install numpy
+PATH=$PATH:/usr/local/cuda-10.0/bin pip install pycuda
+```


### PR DESCRIPTION
The code block had two issues:
1. Markdown requires two newlines to create paragraph. A single newline is interpreted as a (white)space. Enclosing the code in triple backticks enables a code block.
2. Copy paste of line numbers was still present. I've removed them.